### PR TITLE
Implement options page

### DIFF
--- a/package/manifest.json
+++ b/package/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Ricerca su Treccani",
-  "version": "1.0.1",
+  "version": "2.0.0",
 
   "author": "Giuse",
   "description": "Effettua una ricerca su Treccani direttamente dalla barra degli indirizzi del browser.",
@@ -13,5 +13,8 @@
   "omnibox": {
     "keyword": "3c"
   },
-  "permissions": ["https://www.treccani.it/"]
+  "permissions": ["https://www.treccani.it/", "storage"],
+  "options_ui": {
+    "page": "options.html"
+  }
 }

--- a/package/options.html
+++ b/package/options.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="it">
+  <head>
+    <meta charset="utf-8" />
+    <script defer src="options.js"></script>
+  </head>
+  <body>
+    <div class="browser-style">
+      <input type="checkbox" id="alwaysNewTabOption" value="true" />
+      <label for="alwaysNewTabOption">Apri sempre i risultati di ricerca in una nuova scheda</label>
+    </div>
+    <div class="browser-style">
+      <button type="button" class="browser-style">Salva</button>
+    </div>
+  </body>
+</html>

--- a/ts/createSuggestions.ts
+++ b/ts/createSuggestions.ts
@@ -46,18 +46,24 @@ browser.omnibox.onInputEntered.addListener(
   if (!text.startsWith(TreccaniSearch.BaseURL)) {
     url = TreccaniSearch.SearchUrl + text;
   }
-  
-  switch (disposition) {
-    case "currentTab":
-      browser.tabs.update({url});
-      break;
-    case "newForegroundTab":
-      browser.tabs.create({url});
-      break;
-    case "newBackgroundTab":
-      browser.tabs.create({url, active: false});
-      break;
-  }
+
+  // Get user preference (or default option value) and open the page accordingly.
+  browser.storage.local.get("alwaysNewTab").then((item: { [key: string]: boolean}) => {
+    if (item?.alwaysNewTab ?? true) {
+      disposition = "newBackgroundTab";
+    }
+    switch (disposition) {
+      case "currentTab":
+        browser.tabs.update({url});
+        break;
+      case "newForegroundTab":
+        browser.tabs.create({url});
+        break;
+      case "newBackgroundTab":
+        browser.tabs.create({url, active: false});
+        break;
+    }
+  });
 });
 
 function createSuggestionsFromResponse(response: Response) {

--- a/ts/options.ts
+++ b/ts/options.ts
@@ -1,0 +1,14 @@
+// Restore user preference or default option value when opening the options page.
+document.addEventListener("DOMContentLoaded", () => {
+  browser.storage.local.get("alwaysNewTab").then((item: { [key: string]: boolean }) => {
+    let checkBoxElement = document.getElementById("alwaysNewTabOption") as HTMLInputElement;
+    checkBoxElement.checked = item?.alwaysNewTab ?? true;
+  });
+});
+
+// Store user preference when submitting the form (by clicking on "Save" button).
+document.querySelector("button")!.addEventListener("click", () => {
+  let checkBoxElement = document.getElementById("alwaysNewTabOption") as HTMLInputElement;
+  let optionValue = checkBoxElement.checked ? true : false;
+  browser.storage.local.set({alwaysNewTab: optionValue});
+});


### PR DESCRIPTION
Let users choose whether to always open search results in a new tab.

This option is enable by default, because when you need to look for the meaning of a word while you're reading a page (which is one of the commonest use cases), you usually don't want to leave that page and then come back.